### PR TITLE
Update to 1.16.5

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Auto detect text files and perform LF normalization
+* text=auto

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,0 @@
-# Auto detect text files and perform LF normalization
-* text=auto

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ run
 
 # Files from Forge MDK
 forge*changelog.txt
+
+logs/*

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ archivesBaseName = 'spanorama'
 sourceCompatibility = targetCompatibility = compileJava.sourceCompatibility = compileJava.targetCompatibility = '1.8' // Need this here so eclipse task generates correctly.
 
 minecraft {
-    mappings channel: 'snapshot', version: '20200723-1.16.1'
+    mappings channel: 'snapshot', version: '20201028-1.16.3'
     // makeObfSourceJar = true // an Srg named sources jar is made by default. uncomment this to disable.
 
     accessTransformer = file('src/main/resources/META-INF/accesstransformer.cfg')
@@ -79,7 +79,7 @@ minecraft {
 }
 
 dependencies {
-    minecraft 'net.minecraftforge:forge:1.16.3-34.0.0'
+    minecraft 'net.minecraftforge:forge:1.16.5-36.0.54'
 }
 
 jar {

--- a/src/main/java/com/suppergerrie2/panorama/ScreenFlashWarningScreen.java
+++ b/src/main/java/com/suppergerrie2/panorama/ScreenFlashWarningScreen.java
@@ -40,7 +40,7 @@ public class ScreenFlashWarningScreen extends Screen {
         int i = (this.bidiRenderer.func_241862_a() + 1) * 9;
 
         this.addButton(
-                new Button(this.width / 2 - 155, 100 + i, 150, 20, DialogTexts.field_240636_g_,
+                new Button(this.width / 2 - 155, 100 + i, 150, 20, DialogTexts.optionsEnabled(true),
                         (p_230165_1_) -> {
                             if (this.showAgainCheckbox.isChecked()) {
                                 Config.CLIENT.disableFlashWarning.set(true);


### PR DESCRIPTION
Unlike Fabric, Forge isn't backward compatible, this quick update should help pack creators working in 1.16.5 instead of making them use 1.16.3.